### PR TITLE
Updating the GXP11xx and GXP21xx firmware references 

### DIFF
--- a/plugins/xivo-grandstream/1.0.8.6/entry.py
+++ b/plugins/xivo-grandstream/1.0.8.6/entry.py
@@ -23,10 +23,9 @@ execfile_('common.py', common)
 logger = logging.getLogger('plugin.xivo-grandstream')
 
 
-MODELS = [u'GXP1100',u'GXP1105',u'GXP1160',u'GXP1165',
-          u'GXP1400',u'GXP1405',u'GXP1450',
+MODELS = [u'GXP1100',u'GXP1105',
           u'GXP2100',u'GXP2110',u'GXP2120', u'GXP2124']
-VERSION = u'1.0.5.26'
+VERSION = u'1.0.8.6'
 
 
 class GrandstreamPlugin(common['BaseGrandstreamPlugin']):

--- a/plugins/xivo-grandstream/1.0.8.6/entry.py
+++ b/plugins/xivo-grandstream/1.0.8.6/entry.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2013-2014 Avencall
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+import logging
+
+common = {}
+execfile_('common.py', common)
+
+logger = logging.getLogger('plugin.xivo-grandstream')
+
+
+MODELS = [u'GXP1100',u'GXP1105',u'GXP1160',u'GXP1165',
+          u'GXP1400',u'GXP1405',u'GXP1450',
+          u'GXP2100',u'GXP2110',u'GXP2120', u'GXP2124']
+VERSION = u'1.0.5.26'
+
+
+class GrandstreamPlugin(common['BaseGrandstreamPlugin']):
+    IS_PLUGIN = True
+
+    _MODELS = MODELS
+
+    pg_associator = common['BaseGrandstreamPgAssociator'](MODELS, VERSION)

--- a/plugins/xivo-grandstream/1.0.8.6/pkgs/pkgs.db
+++ b/plugins/xivo-grandstream/1.0.8.6/pkgs/pkgs.db
@@ -1,0 +1,71 @@
+[pkg_GXP1100-fw]
+description: Firmware for Grandstream GXP1100
+description_fr: Micrologiciel pour Grandstream GXP1100
+version: 1.0.8.6
+files: GXP110X-fw
+install: grandstream-fw
+
+[pkg_GXP1105-fw]
+description: Firmware for Grandstream GXP1105
+description_fr: Micrologiciel pour Grandstream GXP1105
+version: 1.0.8.6
+files: GXP110X-fw
+install: grandstream-fw 
+
+[pkg_GXP2100-fw]
+description: Firmware for Grandstream GXP2100
+description_fr: Micrologiciel pour Grandstream GXP2100
+version: 1.0.8.6
+files: GXP2100-fw
+install: grandstream-fw
+
+[pkg_GXP2110-fw]
+description: Firmware for Grandstream GXP2110
+description_fr: Micrologiciel pour Grandstream GXP2110
+version: 1.0.8.6
+files: GXP2110-fw
+install: grandstream-fw 
+
+[pkg_GXP2120-fw]
+description: Firmware for Grandstream GXP2120
+description_fr: Micrologiciel pour Grandstream GXP2120
+version: 1.0.8.6
+files: GXP2120-fw
+install: grandstream-fw
+
+[pkg_GXP2124-fw]
+description: Firmware for Grandstream GXP2124
+description_fr: Micrologiciel pour Grandstream GXP2124
+version: 1.0.8.6
+files: GXP2124-fw
+install: grandstream-fw 
+
+[install_grandstream-fw]
+a-b: unzip $FILE1
+
+
+[file_GXP110X-fw]
+url: http://www.grandstream.com/sites/default/files/Resources/Release_GXP110x_1.0.8.6.zip
+size: 6649891
+sha1sum: f3b99cc17becf14e0b4314706606a4cec8236c84
+
+[file_GXP2100-fw]
+url: http://www.grandstream.com/sites/default/files/Resources/Release_GXP2100_1.0.8.6.zip
+size: 7027132
+sha1sum: c0de55f88842c15187f54c28a42d267cb138e079
+
+[file_GXP2110-fw]
+url: http://www.grandstream.com/sites/default/files/Resources/Release_GXP2110_1.0.8.6.zip
+size: 7037371
+sha1sum: 0d6093ca0480288af4cc5aeebd5dffb9dd4c4f3f
+
+[file_GXP2120-fw]
+url: http://www.grandstream.com/sites/default/files/Resources/Release_GXP2120_1.0.8.6.zip
+size: 7037194
+sha1sum: 555169dbfe75d953bb8d4d706d41fbefcdf26f39
+
+[file_GXP2124-fw]
+url: http://www.grandstream.com/sites/default/files/Resources/Release_GXP2124_1.0.8.6.zip
+size: 7065756
+sha1sum: 3ad9dffb5f29a9ca1b24d52f55aaf93476a649d0
+

--- a/plugins/xivo-grandstream/1.0.8.6/plugin-info
+++ b/plugins/xivo-grandstream/1.0.8.6/plugin-info
@@ -1,0 +1,47 @@
+{
+    "version": "0.1",
+    "description": "Plugin for Grandstream GXP11XX and GXP21XX in version 1.0.8.6.",
+    "description_fr": "Greffon pour Grandstream GXP11XX et GXP21XX en version 1.0.8.6.",
+    "vendor" : "Grandstream",
+    "vendor.url" : "http://www.grandstream.com",
+    "vendor.description" : "Grandstream Networks, Inc. is an award-winning designer and ISO 9001 certified manufacturer of next generation IP voice & video products for broadband networks. Grandstream’s products deliver superb sound and picture quality, rich telephony features, full compliance with industry standards, and broad interoperability with most service providers and 3rd party SIP based VoIP products.",
+    "vendor.official" : 0,
+    "capabilities": {
+        "Grandstream, GXP1100, 1.0.8.6": {
+            "sip.lines": 2,
+            "xivo.ha" : 0,
+            "tel.funckeys" : 3,
+            "xivo.tested" : 0
+        },
+        "Grandstream, GXP1105, 1.0.8.6": {
+            "sip.lines": 2,
+            "xivo.ha" : 0,
+            "tel.funckeys" : 3,
+            "xivo.tested" : 0
+        },
+        "Grandstream, GXP2100, 1.0.8.6": {
+            "sip.lines": 4,
+            "xivo.ha" : 1,
+            "tel.funckeys" : 7,
+            "xivo.tested" : 1
+        },
+        "Grandstream, GXP2110, 1.0.8.6": {
+            "sip.lines": 1,
+            "xivo.ha" : 0,
+            "tel.funckeys" : 0,
+            "xivo.tested" : 0
+        },
+        "Grandstream, GXP2120, 1.0.8.6": {
+            "sip.lines": 1,
+            "xivo.ha" : 0,
+            "tel.funckeys" : 0,
+            "xivo.tested" : 0
+        },
+        "Grandstream, GXP2124, 1.0.8.6": {
+            "sip.lines": 1,
+            "xivo.ha" : 0,
+            "tel.funckeys" : 0,
+            "xivo.tested" : 0
+        }
+    }
+}

--- a/plugins/xivo-grandstream/build.py
+++ b/plugins/xivo-grandstream/build.py
@@ -39,3 +39,12 @@ def build_1_0_5_12(path):
 
     check_call(['rsync', '-rlp', '--exclude', '.*',
                 '1.0.5.26/', path])
+
+@target('1.0.8.6', 'xivo-grandstream-1.0.8.6')
+def build_1_0_5_12(path):
+    check_call(['rsync', '-rlp', '--exclude', '.*',
+                '--include', '/templates/*',
+                'common/', path])
+
+    check_call(['rsync', '-rlp', '--exclude', '.*',
+                '1.0.8.6/', path])


### PR DESCRIPTION
Currently these refer to 1.0.5.26 which is no longer available. This patch adds a 1.0.8.6 firmware tree for the appropriate models. GXP11xx and GXP21xx are EOL so this will be the last firmware for them.