### PR TITLE
Updating the GXP116x and GXP14xx firmware references

### DIFF
--- a/plugins/xivo-grandstream/1.0.8.9/entry.py
+++ b/plugins/xivo-grandstream/1.0.8.9/entry.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2013-2014 Avencall
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+import logging
+
+common = {}
+execfile_('common.py', common)
+
+logger = logging.getLogger('plugin.xivo-grandstream')
+
+
+MODELS = [u'GXP1160',u'GXP1165',
+          u'GXP1400',u'GXP1405',u'GXP1450']
+VERSION = u'1.0.8.9'
+
+
+class GrandstreamPlugin(common['BaseGrandstreamPlugin']):
+    IS_PLUGIN = True
+
+    _MODELS = MODELS
+
+    pg_associator = common['BaseGrandstreamPgAssociator'](MODELS, VERSION)

--- a/plugins/xivo-grandstream/1.0.8.9/pkgs/pkgs.db
+++ b/plugins/xivo-grandstream/1.0.8.9/pkgs/pkgs.db
@@ -1,0 +1,53 @@
+[pkg_GXP1160-fw]
+description: Firmware for Grandstream GXP1160
+description_fr: Micrologiciel pour Grandstream GXP1160
+version: 1.0.8.9
+files: GXP116X-fw
+install: grandstream-fw
+
+[pkg_GXP1165-fw]
+description: Firmware for Grandstream GXP1165
+description_fr: Micrologiciel pour Grandstream GXP1165
+version: 1.0.8.9
+files: GXP116X-fw
+install: grandstream-fw 
+
+[pkg_GXP1400-fw]
+description: Firmware for Grandstream GXP1400
+description_fr: Micrologiciel pour Grandstream GXP1400
+version: 1.0.8.9
+files: GXP140X-fw
+install: grandstream-fw
+
+[pkg_GXP1405-fw]
+description: Firmware for Grandstream GXP1405
+description_fr: Micrologiciel pour Grandstream GXP1405
+version: 1.0.8.9
+files: GXP140X-fw
+install: grandstream-fw
+
+[pkg_GXP1450-fw]
+description: Firmware for Grandstream GXP1450
+description_fr: Micrologiciel pour Grandstream GXP1450
+version: 1.0.8.9
+files: GXP1450-fw
+install: grandstream-fw
+
+[install_grandstream-fw]
+a-b: unzip $FILE1
+
+[file_GXP116X-fw]
+url: http://firmware.grandstream.com/Release_GXP116x_1.0.8.9.zip
+size: 6996584
+sha1sum: 9eca518b3189fdf522b0e18febd19e24c54c69ea
+
+[file_GXP140X-fw]
+url: http://firmware.grandstream.com/Release_GXP140x_1.0.8.9.zip
+size: 7028173
+sha1sum: 3bde6a4ad7176b4028ff0f9002b2374f85539533
+
+[file_GXP1450-fw]
+url: http://firmware.grandstream.com/Release_GXP1450_1.0.8.9.zip
+size: 7026846
+sha1sum: 2e5d0e4f94274ba6e764f6812ac4cc22d821e147
+

--- a/plugins/xivo-grandstream/1.0.8.9/plugin-info
+++ b/plugins/xivo-grandstream/1.0.8.9/plugin-info
@@ -1,0 +1,41 @@
+{
+    "version": "0.1",
+    "description": "Plugin for Grandstream GXP116X and GXP14XX in version 1.0.8.9.",
+    "description_fr": "Greffon pour Grandstream GXP116X et GXP14XX en version 1.0.8.9.",
+    "vendor" : "Grandstream",
+    "vendor.url" : "http://www.grandstream.com",
+    "vendor.description" : "Grandstream Networks, Inc. is an award-winning designer and ISO 9001 certified manufacturer of next generation IP voice & video products for broadband networks. Grandstream’s products deliver superb sound and picture quality, rich telephony features, full compliance with industry standards, and broad interoperability with most service providers and 3rd party SIP based VoIP products.",
+    "vendor.official" : 0,
+    "capabilities": {
+        "Grandstream, GXP1160, 1.0.8.9": {
+            "sip.lines": 2,
+            "xivo.ha" : 0,
+            "tel.funckeys" : 3,
+            "xivo.tested" : 0
+        },
+        "Grandstream, GXP1165, 1.0.8.9": {
+            "sip.lines": 2,
+            "xivo.ha" : 0,
+            "tel.funckeys" : 3,
+            "xivo.tested" : 0
+        },
+        "Grandstream, GXP1400, 1.0.8.9": {
+            "sip.lines": 2,
+            "xivo.ha" : 0,
+            "tel.funckeys" : 3,
+            "xivo.tested" : 0
+        },
+        "Grandstream, GXP1405, 1.0.8.9": {
+            "sip.lines": 2,
+            "xivo.ha" : 0,
+            "tel.funckeys" : 3,
+            "xivo.tested" : 0
+        },
+        "Grandstream, GXP1450, 1.0.8.9": {
+            "sip.lines": 2,
+            "xivo.ha" : 0,
+            "tel.funckeys" : 3,
+            "xivo.tested" : 0
+        }
+    }
+}

--- a/plugins/xivo-grandstream/build.py
+++ b/plugins/xivo-grandstream/build.py
@@ -41,10 +41,19 @@ def build_1_0_5_12(path):
                 '1.0.5.26/', path])
 
 @target('1.0.8.6', 'xivo-grandstream-1.0.8.6')
-def build_1_0_5_12(path):
+def build_1_0_8_6(path):
     check_call(['rsync', '-rlp', '--exclude', '.*',
                 '--include', '/templates/*',
                 'common/', path])
 
     check_call(['rsync', '-rlp', '--exclude', '.*',
                 '1.0.8.6/', path])
+
+@target('1.0.8.9', 'xivo-grandstream-1.0.8.9')
+def build_1_0_8_9(path):
+    check_call(['rsync', '-rlp', '--exclude', '.*',
+                '--include', '/templates/*',
+                'common/', path])
+
+    check_call(['rsync', '-rlp', '--exclude', '.*',
+                '1.0.8.9/', path])


### PR DESCRIPTION
Currently these refer to 1.0.5.26 which is no longer available. This patch adds a 1.0.8.9 firmware tree for the appropriate models