### PR TITLE
Updated firmware references to 1.0.3.27 for Grandstream GXP2200

### DIFF
--- a/plugins/xivo-grandstream/1.0.3.27/entry.py
+++ b/plugins/xivo-grandstream/1.0.3.27/entry.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2013-2014 Avencall
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+import logging
+
+common = {}
+execfile_('common.py', common)
+
+logger = logging.getLogger('plugin.xivo-grandstream')
+
+
+MODELS = [u'GXP2200',]
+VERSION = u'1.0.3.27'
+
+
+class GrandstreamPlugin(common['BaseGrandstreamPlugin']):
+    IS_PLUGIN = True
+
+    _MODELS = MODELS
+
+    pg_associator = common['BaseGrandstreamPgAssociator'](MODELS, VERSION)

--- a/plugins/xivo-grandstream/1.0.3.27/pkgs/pkgs.db
+++ b/plugins/xivo-grandstream/1.0.3.27/pkgs/pkgs.db
@@ -1,0 +1,14 @@
+[pkg_GXP2200-fw]
+description: Firmware for Grandstream GXP2200
+description_fr: Micrologiciel pour Grandstream GXP2200
+version: 1.0.3.27
+files: GXP2200-fw
+install: grandstream-fw
+
+[install_grandstream-fw]
+a-b: unzip $FILE1
+
+[file_GXP2200-fw]
+url: http://www.grandstream.com/sites/default/files/Resources/Release_GXP2200_1.0.3.27.zip
+size: 73964236
+sha1sum: 143caa3d3422af5326bb6d3c555c31dbe3e42a8a

--- a/plugins/xivo-grandstream/1.0.3.27/plugin-info
+++ b/plugins/xivo-grandstream/1.0.3.27/plugin-info
@@ -1,0 +1,17 @@
+{
+    "version": "0.1",
+    "description": "Plugin for Grandstream GXP2200 in version 1.0.3.27.",
+    "description_fr": "Greffon pour Grandstream GXP22XX en version 1.0.3.27.",
+    "vendor" : "Grandstream",
+    "vendor.url" : "http://www.grandstream.com",
+    "vendor.description" : "Grandstream Networks, Inc. is an award-winning designer and ISO 9001 certified manufacturer of next generation IP voice & video products for broadband networks. Grandstream’s products deliver superb sound and picture quality, rich telephony features, full compliance with industry standards, and broad interoperability with most service providers and 3rd party SIP based VoIP products.",
+    "vendor.official" : 0,
+    "capabilities": {
+        "Grandstream, GXP2200, 1.0.3.27": {
+            "sip.lines": 2,
+            "xivo.ha" : 0,
+            "tel.funckeys" : 3,
+            "xivo.tested" : 0
+        }
+    }
+}

--- a/plugins/xivo-grandstream/build.py
+++ b/plugins/xivo-grandstream/build.py
@@ -30,6 +30,14 @@ def build_1_0_1_40(path):
     check_call(['rsync', '-rlp', '--exclude', '.*',
                 '1.0.1.40/', path])
 
+@target('1.0.3.27', 'xivo-grandstream-1.0.3.27')
+def build_1_0_3_27(path):
+    check_call(['rsync', '-rlp', '--exclude', '.*',
+                '--include', '/templates/*',
+                'common/', path])
+
+    check_call(['rsync', '-rlp', '--exclude', '.*',
+                '1.0.3.27/', path])
 
 @target('1.0.5.26', 'xivo-grandstream-1.0.5.26')
 def build_1_0_5_12(path):


### PR DESCRIPTION
Currently this refers to 1.0.1.40 which is no longer available. This patch adds a 1.0.3.27 firmware tree. 
The GXP2200 is EOL so there will be no more firmware updates.